### PR TITLE
FIX: Ensure auras in AurasImportantList always shown

### DIFF
--- a/ClassicPlatesPlus/auras.lua
+++ b/ClassicPlatesPlus/auras.lua
@@ -77,10 +77,12 @@ function func:Update_Auras(unit)
                             local hidePassiveCheck = data.isClassic and true or not (hidePassiveAuras and duration == 0);
                             local show = unit ~= "player" and ((AurasShow == 1 and (source == "player" or source == "vehicle")) or AurasShow == 2);
 
-                            local toggle = (
+                            -- The "Important Aura" list gives the user the impression of a Brute Force Whitelist, 
+                            -- where auras added to the list are always shown, regardless of other conditions.
+                            -- The following change to the toggle variable fixes that behavior.
+                            local toggle = data.settings.AurasImportantList[name] or (
                                 hidePassiveCheck and (
                                     show
-                                    or data.settings.AurasImportantList[name]
                                     or unit == "player" and (auraType == "debuffs" or auraType == "buffs" and (Config.AurasSourcePersonal == 1 and source == "player" or Config.AurasSourcePersonal == 2))
                                 )
                             ) and not data.settings.AurasBlacklist[name];


### PR DESCRIPTION
**PROBLEM:** The "Important Aura" list gives the user the impression of an Unconditional/Absolute Whitelist, where auras added to the list are always shown, regardless of other conditions. 

**Example:** _I added Soul Fragments - a Demon Hunter buff with no duration on the buff itself but the orbs do despawn after some time - to the Important List but it is never shown:_
![image](https://github.com/ReubinAuthor/ClassicPlatesPlus/assets/102433904/a2b1aac1-8552-469c-993c-68c90d76fdd5)

**SOLUTION:** Previously, the visibility of auras included in the AurasImportantList depended on several other conditions. This change modifies the 'toggle' variable assignment to ensure that if an aura is in the AurasImportantList, 'toggle' will always evaluate to true and display the aura.

_After applying the suggested changes to the code, the Important Auras list behaves as expected, an unconditional whitelist:_
![image](https://github.com/ReubinAuthor/ClassicPlatesPlus/assets/102433904/a80d77f4-d7ff-41b8-8e45-59782f0fa02f)
